### PR TITLE
Disabling console logging every time that a module is hot reloaded

### DIFF
--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -5,6 +5,11 @@ export function initializeHotReloading(opts, url, waitForUnmount) {
 	Promise
 	.all([SystemJS.import('systemjs-hmr'), SystemJS.import('single-spa')])
 	.then(values => {
+		const hmr = values[0];
+		if (hmr && hmr.setDebugLogging) {
+			hmr.setDebugLogging(false);
+		}
+
 		const singleSpa = values[1];
 
 		evtSource.onmessage = function(e) {


### PR DESCRIPTION
Note that this is dependent on https://github.com/alexisvincent/systemjs-hmr/pull/14 being merged and published, but it is defensive about which version of systemjs-hmr is in use.