### PR TITLE
Update to the latest version of sofe

### DIFF
--- a/src/single-spa-canopy.js
+++ b/src/single-spa-canopy.js
@@ -1,6 +1,5 @@
 import {initializeHotReloading} from './hot-reload.js';
 import deepMerge from 'deepmerge';
-import { getServiceUrl, InvalidServiceName } from 'sofe';
 
 const defaultOpts = {
 	mainContentTransition: true,
@@ -51,48 +50,53 @@ export default function singleSpaCanopy(userOpts) {
 
 function bootstrap(opts) {
 	return new Promise((resolve, reject) => {
-		const blockingPromises = [];
-		let url = '', invalidName = false;
+			const blockingPromises = [];
+			const moduleName = `${opts.childAppName}!sofe`;
+			blockingPromises.push(SystemJS
+				.import('sofe')
+				.then(({getServiceUrl, InvalidServiceName}) => {
+					let url = '', invalidName = false;
 
-		try {
-			url = getServiceUrl(opts.childAppName);
-		} catch (e) {
-			if (e instanceof InvalidServiceName) {
-				console.warn(
-					`The single-spa child app name is not the same as the sofe service!
-					This means that hotloading will not work!`
-				);
-				invalidName = true;
-			} else {
-				throw e;
-			}
-		}
+					try {
+						url = getServiceUrl(opts.childAppName);
+					} catch (e) {
+						if (e instanceof InvalidServiceName) {
+							console.warn(
+								`The single-spa child app name is not the same as the sofe service!
+								This means that hotloading will not work!`
+							);
+							invalidName = true;
+						} else {
+							throw e;
+						}
+					}
+					const overriddenToLocal = url.indexOf('https://localhost') === 0 || url.indexOf('https://ielocal') === 0;
+					const shouldHotload = !invalidName && overriddenToLocal && opts.hotload.dev.enabled;
 
-		const overriddenToLocal = url.indexOf('https://localhost') === 0 || url.indexOf('https://ielocal') === 0;
-		const shouldHotload = !invalidName && overriddenToLocal && opts.hotload.dev.enabled;
+					if (shouldHotload) {
+						initializeHotReloading(opts, url, opts.hotload.dev.waitForUnmount);
+					}
 
-		if (shouldHotload) {
-			initializeHotReloading(opts, url, opts.hotload.dev.waitForUnmount);
-		}
-
-		if (window.Raven) {
-			window.Raven.setTagsContext({
-				[opts.childAppName]: url,
-			});
-		}
-
-		if (opts.featureToggles.length > 0) {
-			blockingPromises.push(
-				SystemJS
-				.import('feature-toggles!sofe')
-				.then(featureToggles => {
-					return featureToggles.fetchFeatureToggles(...opts.featureToggles)
+					if (window.Raven) {
+						window.Raven.setTagsContext({
+							[opts.childAppName]: url,
+						});
+					}
 				})
 			);
-		}
 
-		Promise.all(blockingPromises).then(resolve).catch(reject);
-	});
+			if (opts.featureToggles.length > 0) {
+				blockingPromises.push(
+					SystemJS
+					.import('feature-toggles!sofe')
+					.then(featureToggles => {
+						return featureToggles.fetchFeatureToggles(...opts.featureToggles)
+					})
+				);
+			}
+
+			Promise.all(blockingPromises).then(resolve).catch(reject);
+		});
 }
 
 function mount(opts) {


### PR DESCRIPTION
This is necessary because SystemJS 0.20 no longer has `System.locate`
So the new version of sofe now provides a similar mechanism for getting
the qualified url of a service.

This needs to be released as a major version and only installed with sofe 2.0.*