### PR TITLE
removing support for mainContentTransition (three dots loader) now that it's handled in spalpatine.

### DIFF
--- a/src/single-spa-canopy.js
+++ b/src/single-spa-canopy.js
@@ -12,7 +12,6 @@ import {
 setupListener()
 
 const defaultOpts = {
-	mainContentTransition: true,
 	domElementGetter: null,
 	childAppName: null,
 	featureToggles: [],
@@ -38,10 +37,6 @@ export default function singleSpaCanopy(userOpts) {
 	}
 
 	const opts = deepMerge(defaultOpts, userOpts);
-
-	if (opts.mainContentTransition && !opts.domElementGetter) {
-		throw new Error(`In order to show a transition between apps, single-spa-canopy requires opts.domElementGetter function`);
-	}
 
 	if (typeof opts.childAppName !== 'string') {
 		throw new Error(`single-spa-canopy requires opts.childAppName string`);
@@ -118,14 +113,6 @@ function mount(opts) {
 
 			window.addEventListener('cp:show-overlay-keypress', shouldShowAllOverlays)
 			window.addEventListener('single-spa:routing-event', shouldShowAllText)
-
-			if (opts.mainContentTransition) {
-				const loaderEls = Array.prototype.forEach.call(el.querySelectorAll('.cps-loader.\\+page'), function(loaderEl) {
-					if (loaderEl.parentNode) {
-						loaderEl.parentNode.removeChild(loaderEl);
-					}
-				});
-			}
 		}
 
 		opts.overlay._shouldShowAllOverlays = shouldShowAllOverlays
@@ -154,15 +141,6 @@ function unmount(opts) {
 
 		if (opts.domElementGetter) {
 			el = getDomEl(opts);
-		}
-
-		if (opts.mainContentTransition) {
-			putLoaderIntoEl(el);
-		}
-
-		const cpMainContent = document.getElementById('cp-main-content');
-		if (cpMainContent.childNodes.length === 0) {
-			putLoaderIntoEl(cpMainContent);
 		}
 
 		resolve();
@@ -195,30 +173,6 @@ function unload(opts, props) {
 			.then(() => SystemJS.reload(opts.childAppName));
 	} else {
 		return Promise.reject(`Cannot hotload app '${opts.childAppName}' because SystemJS.trace is false or SystemJS.reload is undefined. Try running localStorage.setItem('common-deps', 'dev') and refreshing the page.`);
-	}
-}
-
-function putLoaderIntoEl(el) {
-	const secondaryNavEl = document.querySelector('.cps-secondarynav');
-	const topNavSecondaryEl = document.querySelector('.cps-topnav-secondary');
-	const topNavEl = document.querySelector('.cps-topnav');
-	const bannerEl = document.querySelector('.cps-banner-global');
-
-	const leftOffset = secondaryNavEl ? secondaryNavEl.clientWidth / 2 : 0;
-	const topOffset = (clientHeight(bannerEl) + clientHeight(topNavEl) + clientHeight(topNavSecondaryEl)) / 2;
-
-	const parsedDoc = domParser.parseFromString(`
-		<div class="cps-loader +page" style="position: fixed; left: calc(50% + ${leftOffset}px); top: calc(50% + ${topOffset}px); transform: translate(-50%, -50%)">
-			<span></span>
-			<span></span>
-			<span></span>
-		</div>
-		`, 'text/html');
-
-	el.appendChild(parsedDoc.documentElement.querySelector('body').children[0]);
-
-	function clientHeight(el) {
-		return el ? el.clientHeight : 0;
 	}
 }
 


### PR DESCRIPTION
See https://github.com/CanopyTax/spalpatine/pull/149 which will take care of this.

Note that the spalpatine implementation doesn't put the three dots back when apps are unmounted. But I don't think that's an important feature.