### PR TITLE
a breaking change to only have a single, default export

### DIFF
--- a/src/overlays.helpers.js
+++ b/src/overlays.helpers.js
@@ -1,4 +1,7 @@
-import { getAppName } from './single-spa-canopy.js'
+export function getAppName (props) {
+  return props.name || props.appName || props.childAppName
+}
+
 const overlayDivClassName = `cp-single-spa-canopy__overlay--div`;
 
 // We will only add the event listener if it isn't already defined and certain localStorage variables are set to true
@@ -12,7 +15,7 @@ if (!window._overlayListenerDefined && canDevOverlayBeTurnedOn()) {
   window._overlayListenerDefined = true
 }
 
-// We don't want our customers to ever see the dev overlay. This will prevent the eventListener from even being created 
+// We don't want our customers to ever see the dev overlay. This will prevent the eventListener from even being created
 //  without the correct localStorage varables being set.
 function canDevOverlayBeTurnedOn () {
   if (typeof localStorage === 'undefined') {

--- a/src/single-spa-canopy.js
+++ b/src/single-spa-canopy.js
@@ -1,5 +1,5 @@
 import deepMerge from 'deepmerge';
-import {setOrRemoveAllOverlays} from './overlays.helpers.js'
+import {setOrRemoveAllOverlays, getAppName} from './overlays.helpers.js'
 
 const defaultOpts = {
   domElementGetter: null,
@@ -42,10 +42,6 @@ export default function singleSpaCanopy(userOpts) {
     unmount: unmount.bind(null, opts),
     unload: unload.bind(null, opts),
   };
-}
-
-export function getAppName (props) {
-  return props.name || props.appName || props.childAppName
 }
 
 function getUrl(props) {
@@ -215,7 +211,7 @@ function getDomEl(opts) {
   return el;
 }
 
-export function forceSetPublicPath(config) {
+function forceSetPublicPath(config) {
   validateConfig(config)
   return Promise
     .resolve()


### PR DESCRIPTION
there were only 3 cases in our codebase where we were using a named import from this library, and they have been updated to not use it anymore.

the reasoning is that mixing named and default exports causes problems in certain module formats and usages, so if we remove one or the other, it works and we can then use the format:system bundles for this library in our app. that then allows us to start using that format for our microservices as well.