### PR TITLE
the real change here is the new exported const __esModule

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,5 @@
 {
 	"presets": [
 		"@babel/preset-env"
-	],
-	"plugins": [
 	]
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "homepage": "https://github.com/CanopyTax/single-spa-canopy#readme",
   "devDependencies": {
-    "@babel/cli": "^7.0.0",
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
-    "rollup": "^1.21.4",
+    "@babel/cli": "^7.7.4",
+    "@babel/core": "^7.7.4",
+    "@babel/preset-env": "^7.7.4",
+    "rollup": "^1.27.8",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^5.1.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,35 +2,25 @@ import babel from 'rollup-plugin-babel'
 import resolve from 'rollup-plugin-node-resolve'
 import {terser} from 'rollup-plugin-terser'
 
-export default [
-  {
-    input: 'src/single-spa-canopy.js',
-    output: {
+export default {
+  input: 'src/single-spa-canopy.js',
+  output: [
+    {
       file: 'lib/amd/single-spa-canopy.min.js',
       format: 'amd',
       sourcemap: true,
     },
-    plugins: [
-      resolve(),
-      babel({
-        exclude: 'node_modules/**'
-      }),
-      terser(),
-    ]
-  },
-  {
-    input: 'src/single-spa-canopy.js',
-    output: {
+    {
       file: 'lib/system/single-spa-canopy.min.js',
       format: 'system',
       sourcemap: true,
-    },
-    plugins: [
-      resolve(),
-      babel({
-        exclude: 'node_modules/**'
-      }),
-      terser(),
-    ]
-  }
-]
+    }
+  ],
+  plugins: [
+    resolve(),
+    babel({
+      exclude: 'node_modules/**'
+    }),
+    terser(),
+  ]
+}

--- a/src/single-spa-canopy.js
+++ b/src/single-spa-canopy.js
@@ -23,8 +23,7 @@ const defaultOpts = {
   },
 };
 
-const domParser = new DOMParser();
-
+export const __esModule = true;
 export default function singleSpaCanopy(userOpts) {
   if (typeof userOpts !== 'object') {
     throw new Error(`single-spa-canopy requires an opts object`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/cli@^7.0.0":
+"@babel/cli@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.7.4.tgz#38804334c8db40209f88c69a5c90998e60cca18b"
   integrity sha512-O7mmzaWdm+VabWQmxuM8hqNrWGGihN83KfhPUzp2lAW4kzIMwBxujXkZbD4fMwKMYY9FXTbDvXsJqU+5XHXi4A==
@@ -25,7 +25,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0":
+"@babel/core@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.4.tgz#37e864532200cb6b50ee9a4045f5f817840166ab"
   integrity sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==
@@ -576,7 +576,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/preset-env@^7.0.0":
+"@babel/preset-env@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.7.4.tgz#ccaf309ae8d1ee2409c85a4e2b5e280ceee830f8"
   integrity sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==
@@ -1990,10 +1990,10 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.21.4:
-  version "1.27.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.5.tgz#d100fb0ffd8353575cb2057152547b9abfddfe59"
-  integrity sha512-8rfVdzuTg2kt8ObD9LNJpEwUN7B6lsl3sHc5fddtgICpLjpYeSf4m2+RftBzcCaBTMi1iYX3Ez8zFT4Gj2nJjg==
+rollup@^1.27.8:
+  version "1.27.8"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.8.tgz#94288a957af9f4c2380b73a17494d87705997d0f"
+  integrity sha512-EVoEV5rAWl+5clnGznt1KY8PeVkzVQh/R0d2s3gHEkN7gfoyC4JmvIVuCtPbYE8NM5Ep/g+nAmvKXBjzaqTsHA==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
why? well, a long story short is that other apps NEED that value to know that single-spa-canopy has a default export. wihtout it, they wrap single-spa-canopy in another object that looks like this: {default: [module]}. so you have to do a .default.default. ugh.

normally these things are handled by babel and/or bundlers (webpack, rollup). however, in our case, for some reason rollup has decided NOT to add that when you only have a default export. so we have to add it manually.