### PR TITLE
Bump Yarn to 4.14.1 + add 7-day minimum release age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,21 @@
+approvedGitRepositories:
+  - "**"
+
 compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: true
+
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages:
+  - "@canopytax/*"
+  - browserslist-config-canopy
+  - canopy-webpack-config
+  - eslint-config-canopy
+  - kremling
+  - single-spa
+  - single-spa-canopy

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
   "dependencies": {
     "deepmerge": "^4.2.2"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.14.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@ampproject/remapping@npm:^2.1.0":


### PR DESCRIPTION
## Summary
- Bumps Yarn 4.9.2 → 4.14.1 (required: `npmMinimalAgeGate` was introduced in Yarn 4.10)
- Adds `npmMinimalAgeGate: 7d` to `.yarnrc.yml` so newly published versions of third-party packages must be at least 7 days old before they can be installed — a defense against npm supply-chain attacks
- Exempts our own packages (`@canopytax/*`, `single-spa`, `single-spa-canopy`, `kremling`, `eslint-config-canopy`, `browserslist-config-canopy`, `canopy-webpack-config`) via `npmPreapprovedPackages`

## Why
Following the recent wave of npm supply-chain attacks (Shai-Hulud, the `nx` compromise, etc.), the 7-day gate gives the community time to detect and respond to a compromised package before our installs pick it up. The escape hatch is `YARN_NPM_MINIMAL_AGE_GATE=0 yarn add ...` when a fast install is genuinely needed.

Part of a coordinated rollout across all ~60 Canopy FE repos.

## Test plan
- [x] `yarn install` exit 0
- [x] `yarn build` exit 0 (rollup compiled 3 bundle outputs)
- [ ] No lint/test scripts in this repo